### PR TITLE
Added yearMin and yearMax options, created a simple demo and linted code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/ampersand-date-view.js
+++ b/ampersand-date-view.js
@@ -114,7 +114,7 @@ module.exports = View.extend({
             requiredMessage: 'Year is required.',
             tests: [
                 function (val) {
-                    if (val < 1900 || val > 2000) return "Invalid year";
+                    if (val < 1900 || val > 2100) return "Invalid year";
                 },
                 function (val) {
                     if (!/^[0-9]+$/.test(val)) return "Year must be a number.";

--- a/ampersand-date-view.js
+++ b/ampersand-date-view.js
@@ -73,6 +73,8 @@ module.exports = View.extend({
     },
 
     render: function () {
+        var self = this;
+
         //call the parent first
         View.prototype.render.apply(this);
         this.input = this.query('input');
@@ -96,10 +98,10 @@ module.exports = View.extend({
             requiredMessage: 'Day is required.',
             tests: [
                 function (val) {
-                    if (val < 1 || val > 31) return "Invalid day.";
+                    if (val < 1 || val > 31) return 'Invalid day.';
                 },
                 function (val) {
-                    if (!/^[0-9]+$/.test(val)) return "Day must be a number.";
+                    if (!/^[0-9]+$/.test(val)) return 'Day must be a number.';
                 }
             ]
         }), '[data-hook=day]');
@@ -114,10 +116,10 @@ module.exports = View.extend({
             requiredMessage: 'Year is required.',
             tests: [
                 function (val) {
-                    if (val < 1900 || val > 2100) return "Invalid year";
+                    if (val < self.yearMin || val > self.yearMax) return 'Year must be between '+self.yearMin+' and '+self.yearMax+'.';
                 },
                 function (val) {
-                    if (!/^[0-9]+$/.test(val)) return "Year must be a number.";
+                    if (!/^[0-9]+$/.test(val)) return 'Year must be a number.';
                 }
             ]
         }), '[data-hook=year]');
@@ -133,6 +135,8 @@ module.exports = View.extend({
         name: 'string',
         dayPlaceholder: ['string', true, ''],
         yearPlaceholder: ['string', true, ''],
+        yearMax: ['number', true, 2100],
+        yearMin: ['number', true, 1900],
         label: ['string', true, ''],
         required: ['boolean', true, true],
         shouldValidate: ['boolean', true, true],
@@ -213,14 +217,14 @@ module.exports = View.extend({
     },
 
     handleInputChanged: function () {
-        if (this.monthSelect.value == '' || this.dayInput.value == '' || this.yearInput.value == '') {
+        if (this.monthSelect.value === '' || this.dayInput.value === '' || this.yearInput.value === '') {
             this.inputValue = null;
         } else {
             this.inputValue = new Date(parseInt(this.yearInput.value), parseInt(this.monthSelect.value), parseInt(this.dayInput.value));
         }
     },
 
-    clean: function (val) {
+    clean: function () {
         return this.inputValue;
     },
 

--- a/demo.js
+++ b/demo.js
@@ -1,0 +1,26 @@
+/*global console, window*/
+// can be run with `npm run demo`
+var DateView = require('./ampersand-date-view');
+var FormView = require('ampersand-form-view');
+
+
+var input = new DateView({
+    label: 'Birth date',
+    name: 'birthDate',
+    yearMax: 2000
+});
+
+var form = document.createElement('form');
+form.innerHTML = '<div data-hook="field-container"></div><input type="submit">';
+
+var formView = new FormView({
+    el: form,
+    fields: [input],
+    submitCallback: function (vals) {
+        console.log(vals);
+    }
+});
+
+window.formView = formView;
+
+document.body.appendChild(formView.el);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "underscore": "^1.6.0"
   },
   "devDependencies": {
+    "ampersand-form-view": "^2.2.0",
+    "beefy": "^2.1.1",
     "browserify": "^5.10.1",
     "function-bind": "^1.0.0",
     "jshint": "^2.5.6",
@@ -46,6 +48,7 @@
   "main": "ampersand-date-view.js",
   "scripts": {
     "start": "run-browser test/index.js",
-    "test": "browserify test/index.js | tape-run | tap-spec"
+    "test": "browserify test/index.js | tape-run | tap-spec",
+    "demo": "beefy demo.js"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,9 +6,9 @@ function isHidden(el) {
     return el.style.display === 'none';
 }
 
-function hasClass(el, klass) {
-    return el.classList.contains(klass);
-}
+// function hasClass(el, klass) {
+//     return el.classList.contains(klass);
+// }
 
 function getSelectText(parent) {
     var sel = parent.querySelector('[data-hook=month] select');
@@ -67,5 +67,25 @@ test('value change', function (t) {
     control.handleInputChanged();
 
     t.equal(control.value.getDate(), 15);
+    t.end();
+});
+
+test('invalid year value change', function (t) {
+    var original = new Date('2000-10-12T08:00:00.000Z');
+    var control = new DateView({
+        name: 'title',
+        value: original,
+        yearMax: 2000
+    });
+
+    control.render();
+
+    var errorMessage = control.el.querySelector('[data-hook=message-container]');
+    t.ok(isHidden(errorMessage), 'error should be hidden to start');
+    control.yearView.setValue('2014', false);
+    control.handleInputChanged();
+    control.beforeSubmit();
+    t.equal(control.value.getFullYear(), 2014);
+    t.ok(!isHidden(errorMessage), 'error should be visible now');
     t.end();
 });


### PR DESCRIPTION
Hey!

Here's a few changes we needed at @sinfo, might be useful for other people as well.

You can now run the demo with: 

```
npm run demo
```

And pass year limits like:

``` js
var input = new DateView({
  label: 'Birth date',
  name: 'birthDate',
  yearMax: 1940,
  yearMax: 2000
});
```

Thanks!
